### PR TITLE
Mac OS Support for agaconv

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,22 @@ Overview of supported features:
 AGAConv uses ffmpeg to extract video frames and audio data from any video format supported by ffmpeg and encodes them into a CDXL video. For HAM conversions it can integrate the tool [ham_convert](http://mrsebe.bplaced.net/blog/wordpress/?page_id=374) into the conversion pipeline. 
 The CDXL video can be played with [AGABlaster](https://cutt.ly/AGABlaster) on a Commodore-Amiga computer.
 
+## Requirements (Ubuntu)
+
+You need to install the following dependencies before you can build:
+
+* **sudo apt install make g++ libpng-dev man-db ffmpeg**
+
+## Requirements (MacOS)
+
+On MacOS you will need to install dependencies via [Homebrew](https://brew.sh):
+
+* **brew install libpng ffmpeg doxygen pandoc**
+
 # Building from source
 
 AGAConv can be built from source and run on Ubuntu as follows:
 
-* **sudo apt install make g++ libpng-dev man-db ffmpeg**
 * **cd agaconv**
 * **make -j6**
 

--- a/src/CDXLEncode.cpp
+++ b/src/CDXLEncode.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cmath>
 #include <memory>
+#include <sstream>
 
 #include "AGAConvException.hpp"
 #include "CDXLEncode.hpp"

--- a/src/CDXLEncode.cpp
+++ b/src/CDXLEncode.cpp
@@ -181,9 +181,16 @@ ByteSequence* CDXLEncode::readAudioData() {
       /* Convert from signed byte -128 .. 127
          to unsigned byte 0 .. 255
       */
-      int8_t audioByte0=(int8_t)_sndFile.get();
-      int8_t audioByte1=(int8_t)audioByte0+128;
-      UBYTE audioByte2=(UBYTE)audioByte1;
+      UBYTE audioByte2;
+      if (!_sndFile.eof()) {
+        int8_t audioByte0=(int8_t)_sndFile.get();
+        int8_t audioByte1=(int8_t)audioByte0+128;
+        audioByte2=(UBYTE)audioByte1;
+        // Make sure the eof bit is set before we try to read again
+        _sndFile.peek();
+      } else {
+        audioByte2 = 0;
+      }
       audioByteSequence->add(audioByte2);
     }
     return audioByteSequence;
@@ -197,9 +204,16 @@ ByteSequence* CDXLEncode::readAudioData() {
       /* Convert from signed byte -128 .. 127
 	 to unsigned byte 0 .. 255
       */
-      int8_t audioByte0=(int8_t)_sndFile.get();
-      int8_t audioByte1=(int8_t)audioByte0+128;
-      UBYTE audioByte2=(UBYTE)audioByte1;
+      UBYTE audioByte2;
+      if (!_sndFile.eof()) {
+        int8_t audioByte0=(int8_t)_sndFile.get();
+        int8_t audioByte1=(int8_t)audioByte0+128;
+        audioByte2=(UBYTE)audioByte1;
+        // Make sure the eof bit is set before we try to read again
+        _sndFile.peek();
+      } else {
+        audioByte2 = 0;
+      }
       if(j%2==0) {
         audioByteSequence->add(audioByte2);
       } else {

--- a/src/CDXLEncode.hpp
+++ b/src/CDXLEncode.hpp
@@ -32,8 +32,8 @@ class CDXLEncode : public FileSequenceConversion {
  public:
   void preVisitFirstFrame() override;
   void visitILBMChunk(IffILBMChunk*) override;
-  void postVisitLastILBMChunk(IffILBMChunk* ilbmChunk);
-  void run(Options& options);
+  void postVisitLastILBMChunk(IffILBMChunk* ilbmChunk) override;
+  void run(Options& options) override;
 
   // AUDIO
   ByteSequence* readAudioData();

--- a/src/CDXLFrame.hpp
+++ b/src/CDXLFrame.hpp
@@ -50,12 +50,12 @@ class CDXLFrame : public CDXLBlock {
   void readChunk() override;
   void writeChunk() override;
   void setOutFile(std::fstream* fstream) override;
-  ULONG getLength();
+  ULONG getLength() override;
   // Alignment defines the boundaries for which pad bytes should be computed
   // e.g. to align for LONG (=4 bytes): computePadBytes(4,13) = 3,
   // computePadBytes(4,4) = 0, computePadBytes(4,2) = 2
   static ULONG computePaddingBytes(ULONG alignment, ULONG size);
-  std::string toString();
+  std::string toString() override;
   // requires the header to be properly initialized
   void importVideo(IffILBMChunk* body);
   ByteSequence* readByteSequence(std::fstream* inFile, ULONG length);

--- a/src/CDXLHeader.hpp
+++ b/src/CDXLHeader.hpp
@@ -72,10 +72,10 @@ class CDXLHeader : public CDXLBlock {
   CDXLHeader();
   CDXLHeader(IffBMHDChunk* bmhdChunk, IffCMAPChunk* cmap, IffCAMGChunk* camg);
   void initialize(IffBMHDChunk* bmhdChunk, IffCMAPChunk* cmap, IffCAMGChunk* camg);
-  void readChunk();
-  void writeChunk();
-  std::string toString();
-  ULONG getLength();
+  void readChunk() override;
+  void writeChunk() override;
+  std::string toString() override;
+  ULONG getLength() override;
   void setFileType(CDXLFileType fileType);
   std::string fileTypeToString();
   void setPreviousChunkSize(ULONG size);

--- a/src/CommandLineParser.cpp
+++ b/src/CommandLineParser.cpp
@@ -82,9 +82,7 @@ void CommandLineParser::splitArgvOnEqualSign(int argc0, char** argv0) {
     }
   }
   argc=argv.size();
-  int i=0;
   for (auto s:argv) {
-    i++;
   }
 }
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -646,7 +646,7 @@ void Configuration::resolveHcPath() {
           std::filesystem::path filePath=dir_entry.path();
           string fileName=filePath.stem();
           string fileExt=filePath.extension();
-          std::regex hamConvertRegex("ham_convert_[0-9]+(\\.[0-9])*");
+          std::regex hamConvertRegex("ham_convert_[0-9]+(\\.[0-9]+)*");
           if(std::regex_match(fileName, hamConvertRegex) && fileExt==".jar") {
             jarFiles.push_back(hcPath/filePath);
           }

--- a/src/IffBODYChunk.cpp
+++ b/src/IffBODYChunk.cpp
@@ -46,7 +46,6 @@ size_t IffBODYChunk::uncompressedLength() {
 }
 
 ByteSequence* IffBODYChunk::getUncompressedData() {
-  assert(this!=0);
   ByteSequence* byteSequence=new ByteSequence();
   // BODY was never compressed. Copy original BODY.
   for(IffDataChunkIterator i=begin();i!=end();++i) {

--- a/src/OSLayer.cpp
+++ b/src/OSLayer.cpp
@@ -2,12 +2,15 @@
 #include "OSLayer.hpp"
 #include "OSLayerFallback.hpp"
 #include "OSLayerLinux.hpp"
+#include "OSLayerMacOs.hpp"
 
 namespace AGAConv {
 
 OSLayer* OSLayer::createOSLayer() {
 #ifdef __linux__
   return new OSLayerLinux();
+#elif __MACH__
+  return new OSLayerMacOs();
 #else
   return new OSLayerFallback();
 #endif

--- a/src/OSLayerMacOs.cpp
+++ b/src/OSLayerMacOs.cpp
@@ -1,0 +1,49 @@
+#include "OSLayerMacOs.hpp"
+#include <filesystem>
+
+#ifdef __MACH__
+
+#include <sys/types.h>
+#include <unistd.h>
+
+using std::string;
+using std::filesystem::path;
+
+namespace AGAConv {
+
+bool OSLayerMacOs::isSupported() {
+  return true;
+}
+
+std::string OSLayerMacOs::redirectOutputToNullDevice() {
+  return ">/dev/null";
+}
+
+bool OSLayerMacOs::isInstalledTool(const std::string& toolName) {
+   std::string testCommand="which "+toolName+" > /dev/null 2>&1";
+   return std::system(testCommand.c_str())==0;
+}
+
+string OSLayerMacOs::getPidString() {
+  pid_t pid = getpid();
+  return std::to_string(pid);
+}
+
+string OSLayerMacOs::getHomeDirString() {
+  return getenv("HOME");
+}
+
+path OSLayerMacOs::getDefaultConfigFileName() {
+  path filePath;
+  path homePath=getHomeDirString();
+  if(!homePath.empty()) {
+    filePath=homePath;
+    filePath/=defaultAgaConvConfigDir;
+    filePath/=defaultConfigFileName;
+  }
+  return filePath;
+}
+
+}
+
+#endif  // __MACH__

--- a/src/OSLayerMacOs.hpp
+++ b/src/OSLayerMacOs.hpp
@@ -1,0 +1,29 @@
+#ifndef OS_LAYER_MACOS_HPP
+#define OS_LAYER_MACOS_HPP
+
+#ifdef __MACH__
+
+#include "OSLayer.hpp"
+#include <string>
+#include <filesystem>
+
+namespace AGAConv {
+
+class OSLayerMacOs : public OSLayer {
+public:
+  bool isSupported() override;
+  std::string redirectOutputToNullDevice() override;
+  bool isInstalledTool(const std::string& toolName) override;
+  std::string getPidString() override;
+  std::filesystem::path getDefaultConfigFileName() override;
+  std::string getHomeDirString() override;
+
+protected:
+  const std::string defaultAgaConvConfigDir=".agaconv";
+  const std::string defaultConfigFileName="default.config";
+};
+
+} // namespace AGAConv
+
+#endif  // __MACH__
+#endif

--- a/src/StageAnimEdit.cpp
+++ b/src/StageAnimEdit.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <sstream>
 
 #include "AGAConvException.hpp"
 #include "CommandLineParser.hpp"


### PR DESCRIPTION
Fixed some compiler errors, adds [src/OSLayerMacOs.cpp](https://github.com/mschordan/agaconv/compare/master...emiespo:agaconv:macos-support?expand=1#diff-d555d7d8973282b9bf6c0b36ae1c7b43fd649698544e90e210ba3a33aa66f752) for Mac OS support.